### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 > 
 > kkgepo, the language of evil, used to speak with k8s.
 
-`kkgepo` is just a bunch of dinamically generated kubectl aliases. It does not check anything, it just substitutes words. But there is more, by selling your soul now you can use `ff`, which allows you to choose a specific resource to apply your actions. 
+`kkgepo` is just a bunch of dynamically generated kubectl aliases. It does not check anything, it just substitutes words. But there is more, by selling your soul now you can use `ff`, which allows you to choose a specific resource to apply your actions.
 `kkgepo` is simple to use and easy to extend, less than 100 python lines. `kkgepo` also includes ksetns and ksetco to set namespace and context respectively using fzf.
 
-Usage with zsh is advised. It works waaay better. Probably suport for bash will be droped in the future due to problems. 
+Usage with zsh is advised. It works waaay better. Probably support for bash will be dropped in the future due to problems.
 
 **Requirements**:
 - fzf


### PR DESCRIPTION
## Summary
- fix typos in README: "dinamically" -> "dynamically", "suport" -> "support", "droped" -> "dropped"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846973eb5f48330920e7ac5c39b02ff