### PR TITLE
Externalize kubectl aliases

### DIFF
--- a/aliases.yaml
+++ b/aliases.yaml
@@ -1,0 +1,39 @@
+commands:
+  ge: get
+  de: describe
+  rm: delete
+  af: "apply --recursive -f"
+  ak: "apply -k"
+  ku: kustomize
+  ed: edit
+  ru: "run --rm --restart=Never --image-pull-policy=IfNotPresent -i -t"
+  lo: "logs -f"
+  ex: "exec -i -t"
+flags:
+  al: --all
+  an: --all-namespaces
+  sl: --show-labels
+  wa: --watch
+  oy: -o=yaml
+  ow: -o=wide
+  oj: -o=json
+resources:
+  no: nodes
+  ns: namespaces
+  dp: deployment
+  st: statefulset
+  po: pods
+  sv: service
+  in: ingress
+  se: secret
+  cm: configmap
+  sa: serviceaccount
+  rd: customresourcedefinition
+  vr: vulnerabilityreport
+  ro: role
+  rb: rolebinding
+  cr: clusterrole
+  cb: clusterrolebinding
+  pv: persistentvolume
+  pc: persistentvolumeclaim
+  ar: all

--- a/kubealias.py
+++ b/kubealias.py
@@ -1,49 +1,24 @@
 import sys
+from pathlib import Path
 
-commands = {
-    'ge': 'get',
-    'de': 'describe',
-    'rm': 'delete',
-    'af': 'apply --recursive -f',
-    'ak': 'apply -k',
-    'ku': 'kustomize',
-    'ed': 'edit',
-    'ru': 'run --rm --restart=Never --image-pull-policy=IfNotPresent -i -t',
-    'lo': 'logs -f',
-    'ex': 'exec -i -t',
-}
+try:
+    from yaml import safe_load
+except Exception:  # PyYAML not available
+    from yaml_fallback import safe_load
 
-flags = {
-    'al': '--all',
-    'an': '--all-namespaces',
-    'sl': '--show-labels',
-    'wa': '--watch',
-    'oy': '-o=yaml',
-    'ow': '-o=wide',
-    'oj': '-o=json',
-}
+ALIASES_FILE = Path(__file__).with_name("aliases.yaml")
 
-resources = {
-    'no': 'nodes',
-    'ns': 'namespaces',
-    'dp': 'deployment',
-    'st': 'statefulset',
-    'po': 'pods',
-    'sv': 'service',
-    'in': 'ingress',
-    'se': 'secret',
-    'cm': 'configmap',
-    'sa': 'serviceaccount',
-    'rd': 'customresourcedefinition',
-    'vr': 'vulnerabilityreport',
-    'ro': 'role',
-    'rb': 'rolebinding',
-    'cr': 'clusterrole',
-    'cb': 'clusterrolebinding',
-    'pv': 'persistentvolume',
-    'pc': 'persistentvolumeclaim',
-    'ar': 'all', # all resources
-}
+try:
+    with open(ALIASES_FILE, "r") as f:
+        _ALIASES = safe_load(f)
+except FileNotFoundError:
+    _ALIASES = {"commands": {}, "flags": {}, "resources": {}}
+
+commands = _ALIASES.get("commands", {})
+
+flags = _ALIASES.get("flags", {})
+
+resources = _ALIASES.get("resources", {})
 
 def print_help():
     groups = {

--- a/yaml_fallback.py
+++ b/yaml_fallback.py
@@ -1,0 +1,21 @@
+"""Minimal YAML parser implementing a subset of PyYAML's API."""
+
+def safe_load(stream):
+    if hasattr(stream, "read"):
+        content = stream.read()
+    else:
+        content = str(stream)
+
+    result = {}
+    current = None
+    for line in content.splitlines():
+        line = line.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if not line.startswith(" "):
+            current = line.rstrip(":")
+            result[current] = {}
+        else:
+            key, value = line.strip().split(":", 1)
+            result[current][key.strip()] = value.strip().strip('"')
+    return result


### PR DESCRIPTION
## Summary
- move alias configuration to `aliases.yaml`
- import `safe_load` from PyYAML when available with fallback parser

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846c2c064688330952fd62da1c0c275