### PR TITLE
Enforce KKGEPO_ALIASES for alias loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Usage with zsh is advised. It works waaay better. Probably support for bash will
 
 **Installation**: `source ~/kkgepo/kubealiasrc`
 
-By default the tool loads its aliases from the `aliases.yaml` file next to
-`main.py`. This path can be overridden by setting the `KKGEPO_ALIASES`
-environment variable to point at a different YAML file.
+The tool now requires the `KKGEPO_ALIASES` environment variable to point
+at the YAML file containing all the alias definitions.  If the variable is
+missing, `kkgepo` will print an error message and load no aliases.
 
 **Managing dependencies**:
 This project uses [uv](https://github.com/astral-sh/uv) for dependency

--- a/main.py
+++ b/main.py
@@ -8,13 +8,17 @@ except Exception:  # PyYAML not available
     from src.yaml_fallback import safe_load
 
 _aliases_env = os.environ.get("KKGEPO_ALIASES")
-ALIASES_FILE = Path(_aliases_env).expanduser() if _aliases_env else Path(__file__).with_name("aliases.yaml")
-
-try:
-    with open(ALIASES_FILE, "r") as f:
-        _ALIASES = safe_load(f)
-except FileNotFoundError:
+if not _aliases_env:
+    print("KKGEPO_ALIASES environment variable is not set", file=sys.stderr)
     _ALIASES = {"commands": {}, "flags": {}, "resources": {}}
+else:
+    ALIASES_FILE = Path(_aliases_env).expanduser()
+    try:
+        with open(ALIASES_FILE, "r") as f:
+            _ALIASES = safe_load(f)
+    except FileNotFoundError:
+        print(f"Alias file not found: {ALIASES_FILE}", file=sys.stderr)
+        _ALIASES = {"commands": {}, "flags": {}, "resources": {}}
 
 commands = _ALIASES.get("commands", {})
 

--- a/tests/test_kubealias.py
+++ b/tests/test_kubealias.py
@@ -78,9 +78,23 @@ class TestKubealias(unittest.TestCase):
             importlib.reload(main)
             self.assertEqual(main.create_command(["prog", "xx"]), "kubectl foo")
         finally:
-            os.environ.pop("KKGEPO_ALIASES", None)
+            os.environ["KKGEPO_ALIASES"] = os.path.join(ROOT_DIR, "aliases.yaml")
             importlib.reload(main)
             Path(temp_path).unlink()
+
+    def test_error_when_env_var_missing(self) -> None:
+        """Reloading the module without ``KKGEPO_ALIASES`` prints an error."""
+        import importlib
+        from io import StringIO
+        import contextlib
+
+        os.environ.pop("KKGEPO_ALIASES", None)
+        stderr = StringIO()
+        with contextlib.redirect_stderr(stderr):
+            importlib.reload(main)
+        self.assertIn("KKGEPO_ALIASES", stderr.getvalue())
+        os.environ["KKGEPO_ALIASES"] = os.path.join(ROOT_DIR, "aliases.yaml")
+        importlib.reload(main)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require `KKGEPO_ALIASES` environment variable instead of falling back to the default file
- document the new requirement in the README
- update tests and add coverage for the missing variable case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d3dc458883308d712141cf833b61