### PR TITLE
Update GitHub workflow to use v4 actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build kk.pex
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv pex
+      - name: Build kk.pex
+        run: |
+          uv pip compile pyproject.toml > requirements.txt
+          pex -r requirements.txt -o kk.pex --exe main.py
+      - name: Upload kk.pex
+        uses: actions/upload-artifact@v4
+        with:
+          name: kk-pex
+          path: kk.pex


### PR DESCRIPTION
## Summary
- bump `checkout` and `upload-artifact` steps to version 4

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d5c755c4833092ff03b870c1cb85