### PR TITLE
Add execution mode with optional print flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ uv pip install -e ".[develop]"
 Usage:
         main.py <alias1> <alias2> ...
 
+The generated kubectl command is executed automatically. Use ``--print`` (or
+``-p``) to display the command without executing it.
+
 Resources:
         po => pods
         dp => deployment

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+import subprocess
 
 try:
     from yaml import safe_load
@@ -79,5 +80,25 @@ def create_command(args: list):
 
     return command
 
+
+def main(argv: list[str] | None = None) -> None:
+    """Execute or print the command generated from ``argv``.
+
+    The optional ``--print``/``-p`` flag causes the command to be printed
+    instead of executed.
+    """
+
+    argv = argv or sys.argv
+    print_only = False
+    if len(argv) > 1 and argv[1] in ("--print", "-p"):
+        print_only = True
+        argv = [argv[0]] + argv[2:]
+
+    cmd = create_command(argv)
+    if print_only:
+        print(cmd)
+    else:
+        subprocess.run(cmd, shell=True, check=False)
+
 if __name__ == '__main__':
-    print(create_command(sys.argv))
+    main()

--- a/tests/test_kubealias.py
+++ b/tests/test_kubealias.py
@@ -96,6 +96,24 @@ class TestKubealias(unittest.TestCase):
         os.environ["KKGEPO_ALIASES"] = os.path.join(ROOT_DIR, "aliases.yaml")
         importlib.reload(main)
 
+    def test_main_executes_command(self) -> None:
+        """``main.main`` should execute the generated command by default."""
+        from unittest import mock
+
+        with mock.patch("subprocess.run") as run_mock:
+            main.main(["prog", "gepo"])
+            run_mock.assert_called_once_with("kubectl get pods", shell=True, check=False)
+
+    def test_main_print_flag(self) -> None:
+        """When ``--print`` is provided the command is printed only."""
+        from io import StringIO
+        from unittest import mock
+        out = StringIO()
+        with mock.patch("subprocess.run") as run_mock, mock.patch("sys.stdout", out):
+            main.main(["prog", "--print", "gepo"])
+            run_mock.assert_not_called()
+        self.assertEqual(out.getvalue().strip(), "kubectl get pods")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enable executing generated kubectl commands from Python
- add `--print` flag to show the command without running
- document the new behaviour in README
- test main entry behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d886c5d08330b0dcbb4e567e9e12