### PR TITLE
Fix release workflow for tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
           path: kk.pex
 
   release:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
## Summary
- only attempt GitHub release when running on a tag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846dba0b278833084616107161d22fc