### PR TITLE
Improve ff alias usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The tool now requires the `KKGEPO_ALIASES` environment variable to point
 at the YAML file containing all the alias definitions.  If the variable is
 missing, `kkgepo` will print an error message and load no aliases.
 
+The optional `FZFTAB_CMD` environment variable allows overriding the command
+used by the special `ff` alias. If unset, a default `fzf` invocation is used so
+`kk.pex` works even when the helper aliases from `kubealiasrc` are not loaded.
+
 ## Project layout
 
 ```

--- a/main.py
+++ b/main.py
@@ -67,13 +67,19 @@ def create_command(args: list):
 
     subs = {**commands, **flags, **resources}
     command: str = 'kubectl'
+    fzftab_cmd = os.environ.get(
+        "FZFTAB_CMD",
+        "fzf --height=13 --border --reverse --pointer '>' --header-lines=1 --color 'header:reverse'",
+    )
     for a in alias:
-        if a in subs: # adds command, flag, or resource to shell command
+        if a in subs:  # adds command, flag, or resource to shell command
             command += f" {subs[a]}"
-            
-        elif a == 'ff': # fzf over resources. Default to pod.
+
+        elif a == 'ff':  # fzf over resources. Default to pod.
             alias_resource = next((res for res in alias if res in resources), 'po')
-            command += f" $(kubectl get {subs[alias_resource]} | fzftab | awk '{{print $1}}')"
+            command += (
+                f" $(kubectl get {subs[alias_resource]} | {fzftab_cmd} | awk '{{print $1}}')"
+            )
 
         else: # alias not found
             return f"echo \"Alias not found: '{a}'. Call the script without arguments for help.\""

--- a/tests/test_kubealias.py
+++ b/tests/test_kubealias.py
@@ -58,7 +58,10 @@ class TestKubealias(unittest.TestCase):
     def test_ff_alias_builds_fzf_command(self) -> None:
         """The special ``ff`` alias should inject the fzf command snippet."""
         result = main.create_command(["prog", "geffpo"])
-        snippet = "$(kubectl get pods | fzftab | awk '{print $1}')"
+        snippet = (
+            "$(kubectl get pods | fzf --height=13 --border --reverse --pointer '>' "
+            "--header-lines=1 --color 'header:reverse' | awk '{print $1}')"
+        )
         self.assertIn(snippet, result)
         self.assertTrue(result.startswith("kubectl get "))
         self.assertTrue(result.endswith(" pods"))


### PR DESCRIPTION
## Summary
- add fallback `FZFTAB_CMD` logic so `ff` works even without the shell alias
- adjust README with docs on `FZFTAB_CMD`
- update tests for new default snippet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846db00803c833090af496b2ee8b45b