### PR TITLE
Update help behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ uv pip install -e ".[develop]"
 **Help**:
 ```
 Usage:
-        main.py <alias1> <alias2> ...
+        main.py [-p] <alias1> <alias2> ...
 
 The generated kubectl command is executed automatically. Use ``--print`` (or
 ``-p``) to display the command without executing it.

--- a/tests/test_kubealias.py
+++ b/tests/test_kubealias.py
@@ -43,17 +43,26 @@ class TestKubealias(unittest.TestCase):
                 )
 
     def test_help_shown_when_no_alias_provided(self) -> None:
-        """When no alias is given, the help message should be returned."""
-        result = main.create_command(["prog"])
-        self.assertIn("Usage:", result)
+        """When no alias is given, the help message should be printed."""
+        from io import StringIO
+        import contextlib
+
+        out = StringIO()
+        with contextlib.redirect_stdout(out):
+            result = main.create_command(["prog"])
+        self.assertIsNone(result)
+        self.assertIn("Usage:", out.getvalue())
 
     def test_unknown_alias_returns_message(self) -> None:
-        """An unknown alias should return an informative error message."""
-        result = main.create_command(["prog", "gezz"])
-        self.assertEqual(
-            result,
-            "echo \"Alias not found: 'zz'. Call the script without arguments for help.\"",
-        )
+        """An unknown alias should print an informative error message."""
+        from io import StringIO
+        import contextlib
+
+        out = StringIO()
+        with contextlib.redirect_stdout(out):
+            result = main.create_command(["prog", "gezz"])
+        self.assertIsNone(result)
+        self.assertIn("Alias not found", out.getvalue())
 
     def test_ff_alias_builds_fzf_command(self) -> None:
         """The special ``ff`` alias should inject the fzf command snippet."""


### PR DESCRIPTION
## Summary
- print help and errors directly from Python
- return None when help or error is printed
- update tests for new output behavior

## Testing
- `pip install -e .[develop]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847e99b6604833083c275944bacd615